### PR TITLE
Fix importing pages with the same slug but different parents

### DIFF
--- a/db/cms_seeds/sample-site/pages/index/child_b/child_a/content.html
+++ b/db/cms_seeds/sample-site/pages/index/child_b/child_a/content.html
@@ -1,0 +1,6 @@
+[attributes]
+label: Child of Child Seed Page
+layout: nested
+
+[textares content]
+Child A of Child B Page Seed Content

--- a/lib/comfortable_media_surfer/seeds/page/importer.rb
+++ b/lib/comfortable_media_surfer/seeds/page/importer.rb
@@ -29,7 +29,7 @@ module ComfortableMediaSurfer::Seeds::Page
       # setting page record
       page =
         if parent.present?
-          child = site.pages.where(slug: slug).first_or_initialize
+          child = site.pages.where(slug: slug, parent_id: parent.id).first_or_initialize
           child.parent = parent
           child
         else

--- a/test/integration/seeds_test.rb
+++ b/test/integration/seeds_test.rb
@@ -25,7 +25,7 @@ class SeedsIntergrationTest < ActionDispatch::IntegrationTest
     Comfy::Cms::Page.destroy_all
     Comfy::Cms::Snippet.destroy_all
 
-    assert_difference 'Comfy::Cms::Page.count', 3 do
+    assert_difference 'Comfy::Cms::Page.count', 4 do
       assert_difference 'Comfy::Cms::Layout.count', 2 do
         assert_difference 'Comfy::Cms::Snippet.count', 1 do
           get '/'
@@ -62,7 +62,7 @@ class SeedsIntergrationTest < ActionDispatch::IntegrationTest
     Comfy::Cms::Page.destroy_all
     Comfy::Cms::Snippet.destroy_all
 
-    assert_difference 'Comfy::Cms::Page.count', 3 do
+    assert_difference 'Comfy::Cms::Page.count', 4 do
       assert_difference 'Comfy::Cms::Layout.count', 2 do
         assert_difference 'Comfy::Cms::Snippet.count', 1 do
           r :get, "/admin/sites/#{@site.id}/pages"

--- a/test/lib/seeds/pages_test.rb
+++ b/test/lib/seeds/pages_test.rb
@@ -12,7 +12,7 @@ class SeedsPagesTest < ActiveSupport::TestCase
   def test_creation
     Comfy::Cms::Page.delete_all
 
-    assert_difference -> { Comfy::Cms::Page.count }, 3 do
+    assert_difference -> { Comfy::Cms::Page.count }, 4 do
       assert_difference -> { Comfy::Cms::Translation.count }, 2 do
         ComfortableMediaSurfer::Seeds::Page::Importer.new('sample-site', 'default-site').import!
       end
@@ -71,6 +71,10 @@ class SeedsPagesTest < ActiveSupport::TestCase
     assert child_page_b = Comfy::Cms::Page.find_by(full_path: '/child_b')
     assert_equal page, child_page_b.parent
 
+    assert child_page_b_a = Comfy::Cms::Page.find_by(full_path: '/child_b/child_a')
+    assert_equal child_page_a.slug, child_page_b_a.slug
+    assert_equal child_page_b, child_page_b_a.parent
+
     assert_equal child_page_b, child_page_a.target_page
 
     assert_equal 2, page.translations.count
@@ -93,7 +97,7 @@ class SeedsPagesTest < ActiveSupport::TestCase
     child = comfy_cms_pages(:child)
     child.update_column(:slug, 'old')
 
-    assert_difference -> { Comfy::Cms::Page.count } do
+    assert_difference -> { Comfy::Cms::Page.count }, 2 do
       ComfortableMediaSurfer::Seeds::Page::Importer.new('sample-site', 'default-site').import!
 
       @page.reload

--- a/test/lib/seeds_test.rb
+++ b/test/lib/seeds_test.rb
@@ -9,7 +9,7 @@ class SeedsTest < ActiveSupport::TestCase
     Comfy::Cms::Snippet.destroy_all
 
     assert_difference(-> { Comfy::Cms::Layout.count }, 2) do
-      assert_difference(-> { Comfy::Cms::Page.count }, 3) do
+      assert_difference(-> { Comfy::Cms::Page.count }, 4) do
         assert_difference(-> { Comfy::Cms::Snippet.count }, 1) do
           ComfortableMediaSurfer::Seeds::Importer.new('sample-site', 'default-site').import!
         end


### PR DESCRIPTION
Some sites have a complex nesting structure, in which case different parent pages may have children with the same slugs. But current import implementation doesn't work correctly. It overwrites all pages with the same slug to the last one.
