### PR TITLE
Fix ‘Deep nesting of tags’ error for pages containing more than MAX_DEPTH tags

### DIFF
--- a/lib/comfortable_media_surfer/content/renderer.rb
+++ b/lib/comfortable_media_surfer/content/renderer.rb
@@ -39,15 +39,15 @@ class ComfortableMediaSurfer::Content::Renderer
   # @param [Comfy::Cms::WithFragments, nil] context
   def initialize(context)
     @context = context
-    @depth   = 0
   end
 
   # This is how we render content out. Takes context (cms page) and content
   # nodes
   # @param [Array<String, ComfortableMediaSurfer::Content::Tag>]
   # @param [Boolean] allow_erb
-  def render(nodes, allow_erb = ComfortableMediaSurfer.config.allow_erb)
-    if (@depth += 1) > MAX_DEPTH
+  # @param [Integer] depth current tag nesting position
+  def render(nodes, allow_erb = ComfortableMediaSurfer.config.allow_erb, depth = 0)
+    if depth >= MAX_DEPTH
       raise Error, 'Deep tag nesting or recursive nesting detected'
     end
 
@@ -58,7 +58,7 @@ class ComfortableMediaSurfer::Content::Renderer
       else
         tokens  = tokenize(node.render)
         nodes   = nodes(tokens)
-        render(nodes, allow_erb || node.allow_erb?)
+        render(nodes, allow_erb || node.allow_erb?, depth.next)
       end
     end.flatten.join
   end

--- a/test/lib/content/renderer_test.rb
+++ b/test/lib/content/renderer_test.rb
@@ -275,4 +275,13 @@ class ContentRendererTest < ActiveSupport::TestCase
       render_string('{{cms:snippet default}}')
     end
   end
+
+  def test_render_with_more_than_max_depth_tags_but_without_stack_overflow
+    test_string =
+      Array.new(ComfortableMediaSurfer::Content::Renderer::MAX_DEPTH * 2) { '{{cms:text content}}' }.join(' ')
+    out = render_string(test_string)
+    expected =
+      Array.new(ComfortableMediaSurfer::Content::Renderer::MAX_DEPTH * 2) { 'content' }.join(' ')
+    assert_equal expected, out
+  end
 end


### PR DESCRIPTION
When a page contains more than MAX_DEPTH tags, it cannot be rendered due to the ‘Deep tag nesting or recursive nesting detected’ error. But the actual problem is that the @depth counter is incremented when rendering each tag, but not the nested one.
