### PR TITLE
Remove jQuery from script after destroying files

### DIFF
--- a/app/views/comfy/admin/cms/files/destroy.js.erb
+++ b/app/views/comfy/admin/cms/files/destroy.js.erb
@@ -1,4 +1,4 @@
 (() => {
   const listItem = document.querySelector('li[data-id="<%= @file.id %>"]');
-  jQuery(listItem).fadeOut('slow', () => listItem.remove());
+  listItem.remove();
 })();


### PR DESCRIPTION
### Summary

Removed jQuery fade effect because jQuery is no longer exported in window.