### PR TITLE
Strip possible spaces around exclude page slugs

### DIFF
--- a/lib/comfortable_media_surfer/content/tags/children.rb
+++ b/lib/comfortable_media_surfer/content/tags/children.rb
@@ -25,7 +25,7 @@ class ComfortableMediaSurfer::Content::Tags::Children < ComfortableMediaSurfer::
     @style  = ''
     @style  = "<style>#children {#{@locals['style']}}</style>\n" if @locals['style']
     @exclude = []
-    @exclude = @locals['exclude'].split(',') if @locals['exclude']
+    @exclude = @locals['exclude'].split(',').map(&:strip) if @locals['exclude']
     @list = ''
     # ActiveRecord_Associations_CollectionProxy
     @page_children = context.children.order(:position).to_ary


### PR DESCRIPTION
### Summary

Inline example mentions:

```
{{ cms:children style: "font-weight: bold", exclude: "404-page, search-page" }}
```

But the last element in `exclude` array has space before the slug and will return false

```ruby
["404-page", " search-page"].include? "search-page"
# => false
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed whitespace handling in exclude lists to ensure slugs with leading or trailing spaces are properly parsed and applied.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->