### PR TITLE
Bug: Cannot create root/home page

### DIFF
--- a/app/models/comfy/cms/page.rb
+++ b/app/models/comfy/cms/page.rb
@@ -36,7 +36,7 @@ class Comfy::Cms::Page < ActiveRecord::Base
             presence: true,
             uniqueness: { scope: :parent_id },
             unless: ->(p) {
-              p.site && (p.site.pages.none? || p.site.pages.root == self)
+              p.site && (!p.site.pages.exists? || p.site.pages.root == self)
             }
   validate :validate_target_page
   validate :validate_format_of_unescaped_slug

--- a/test/controllers/comfy/admin/cms/pages_controller_test.rb
+++ b/test/controllers/comfy/admin/cms/pages_controller_test.rb
@@ -224,6 +224,34 @@ class Comfy::Admin::Cms::PagesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_creation_root_page
+    # Make sure there are no pages to start with
+    @site.pages.clear
+
+    assert_difference 'Comfy::Cms::Page.count' do
+      assert_difference 'Comfy::Cms::Fragment.count', 2 do
+        r :post, comfy_admin_cms_site_pages_path(site_id: @site), params: {
+          page: {
+            label: 'Home Page',
+            layout_id: @layout.id,
+            fragments_attributes: [
+              { identifier: 'default_page_text',
+                content: 'content content' },
+              { identifier: 'default_field_text',
+                content: 'title content' }
+            ]
+          },
+          commit: 'Create Page'
+        }
+        assert_response :redirect
+        page = Comfy::Cms::Page.last
+        assert_equal @site, page.site
+        assert_redirected_to action: :edit, id: page
+        assert_equal 'Page created, siblings, and parent updated', flash[:success]
+      end
+    end
+  end
+
   def test_creation_with_files
     assert_difference 'Comfy::Cms::Page.count' do
       assert_difference 'Comfy::Cms::Fragment.count', 3 do


### PR DESCRIPTION
### Summary

As I understand the condition, presence and uniqueness validation scoped to parent_id should only be triggered if page exists for the current site or the page is not the root page.

Seems like this was introduced in #44 - changing `count.zero?` to `none?`

Using `site.pages.none?` seems to track in-memory records instantiated in `PagesController#build_page` as well, while `exists?` does a DB level check without full table scan.

Additionally, the slug field is not available when creating the first page

<img width="1288" height="629" alt="Screenshot 2026-01-23 at 8 58 42 AM" src="https://github.com/user-attachments/assets/4e583999-d5ec-4f97-ada5-1a16e938a843" />

Therefore `slug` presence validation should not be triggered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved page slug validation logic to more reliably check site page availability when validating slug uniqueness.

* **Tests**
  * Added test coverage for root-level page creation workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->