### PR TITLE
Fix wrong number of arguments (given 1, expected 0)

### DIFF
--- a/lib/comfortable_media_surfer/content/tags/date.rb
+++ b/lib/comfortable_media_surfer/content/tags/date.rb
@@ -7,7 +7,7 @@ class ComfortableMediaSurfer::Content::Tags::Date < ComfortableMediaSurfer::Cont
   def form_field(object_name, view, index)
     name    = "#{object_name}[fragments_attributes][#{index}][datetime]"
     options = { id: form_field_id, class: 'form-control', data: { 'cms-date' => true } }
-    value   = content.present? ? content.to_s(:db) : ''
+    value   = content.present? ? content.to_fs(:db) : ''
     input   = view.send(:text_field_tag, name, value, options)
 
     yield input

--- a/lib/comfortable_media_surfer/content/tags/datetime.rb
+++ b/lib/comfortable_media_surfer/content/tags/datetime.rb
@@ -30,7 +30,7 @@ class ComfortableMediaSurfer::Content::Tags::Datetime < ComfortableMediaSurfer::
   def form_field(object_name, view, index)
     name    = "#{object_name}[fragments_attributes][#{index}][datetime]"
     options = { id: form_field_id, class: 'form-control', data: { 'cms-datetime' => true } }
-    value   = content.present? ? content.to_s(:db) : ''
+    value   = content.present? ? content.to_fs(:db) : ''
     input   = view.send(:text_field_tag, name, value, options)
 
     yield input

--- a/test/controllers/comfy/admin/cms/pages_controller_test.rb
+++ b/test/controllers/comfy/admin/cms/pages_controller_test.rb
@@ -171,6 +171,25 @@ class Comfy::Admin::Cms::PagesControllerTest < ActionDispatch::IntegrationTest
     assert_select "select[data-url='/admin/sites/#{@site.id}/pages/#{@page.id}/form_fragments']"
   end
 
+  def test_get_edit_page_with_date
+    @layout.update_column(:content, '{{cms:textarea content}}{{cms:datetime expires_on, strftime: "%B %d, %Y" }}')
+    @page.update(fragments_attributes: [
+      { identifier: 'expires_on',
+        tag: 'datetime',
+        datetime: comfy_cms_fragments(:datetime).datetime },
+      { identifier: 'content',
+        tag: 'textarea',
+        content: 'demo content' }
+    ])
+
+    r :get, edit_comfy_admin_cms_site_page_path(site_id: @site, id: @page)
+    assert_response :success
+    assert assigns(:page)
+    assert_template :edit
+    assert_select "form[action='/admin/sites/#{@site.id}/pages/#{@page.id}']"
+    assert_select "select[data-url='/admin/sites/#{@site.id}/pages/#{@page.id}/form_fragments']"
+  end
+
   def test_get_edit_failure
     r :get, edit_comfy_admin_cms_site_page_path(site_id: @site, id: 'not_found')
     assert_response :redirect


### PR DESCRIPTION
### Summary

`to_s` no longer expects an argument, use `Time#to_fs(:db)` instead

#### Steps to reproduce 

1. Create layout with date or datetime content tag i.e. `{{ cms:date expires_on }}`
2. Create new page and select layout created in step 1
3. Set value in `Expires On` field, then click "Create Page"
4. Redirect to edit page renders "ActionView::Template::Error: wrong number of arguments (given 1, expected 0)" exception

#### Stacktrace

```
ArgumentError: wrong number of arguments (given 1, expected 0) (ArgumentError)
    from active_support/time_with_zone.rb:216:in 'to_s'
    from comfortable_media_surfer/content/tags/date.rb:10:in 'form_field'
    from comfortable_media_surfer/form_builder.rb:10:in 'fragment_field'
    from bundle/ruby/3.4.0/gems/comfortable_media_surfer-3.1.5/app/views/comfy/admin/cms/fragments/_form_fragments.html.haml:33
    from bundle/ruby/3.4.0/gems/comfortable_media_surfer-3.1.5/app/views/comfy/admin/cms/fragments/_form_fragments.html.haml:32:in 'each'
    from bundle/ruby/3.4.0/gems/comfortable_media_surfer-3.1.5/app/views/comfy/admin/cms/fragments/_form_fragments.html.haml:32
    from bundle/ruby/3.4.0/gems/comfortable_media_surfer-3.1.5/app/views/comfy/admin/cms/fragments/_form_fragments.html.haml:30:in 'each'
    from bundle/ruby/3.4.0/gems/comfortable_media_surfer-3.1.5/app/views/comfy/admin/cms/fragments/_form_fragments.html.haml:30:in 'each_with_index'
    from bundle/ruby/3.4.0/gems/comfortable_media_surfer-3.1.5/app/views/comfy/admin/cms/fragments/_form_fragments.html.haml:30
    from action_view/helpers/capture_helper.rb:50:in 'block in ActionView::Helpers::CaptureHelper#capture'
    from action_view/buffers.rb:75:in 'capture'
    from action_view/helpers/capture_helper.rb:50:in 'capture'
    from action_view/helpers/form_helper.rb:1088:in 'fields'
    from bundle/ruby/3.4.0/gems/comfortable_media_surfer-3.1.5/app/views/comfy/admin/cms/fragments/_form_fragments.html.haml:29
    from action_view/base.rb:281:in 'public_send'
    from action_view/base.rb:281:in '_run'
    from action_view/template.rb:284:in 'block in ActionView::Template#render'
    from active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'
    from active_support/notifications/instrumenter.rb:58:in 'instrument'
    from active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'
    from action_view/template.rb:583:in 'instrument_render_template'
    from action_view/template.rb:272:in 'render'
    from action_view/renderer/partial_renderer.rb:268:in 'block in ActionView::PartialRenderer#render_partial_template'
    from active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'
    from active_support/notifications/instrumenter.rb:58:in 'instrument'
    from active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'
    from action_view/renderer/partial_renderer.rb:262:in 'render_partial_template'
    from action_view/renderer/partial_renderer.rb:253:in 'render'
    from action_view/renderer/renderer.rb:78:in 'render_partial_to_object'
    from action_view/renderer/renderer.rb:49:in 'render_partial'
    from action_view/helpers/rendering_helper.rb:152:in 'render'
    from bundle/ruby/3.4.0/gems/comfortable_media_surfer-3.1.5/app/views/comfy/admin/cms/pages/_form.html.haml:17
    from action_view/base.rb:281:in 'public_send'
    from action_view/base.rb:281:in '_run'
    from action_view/template.rb:284:in 'block in ActionView::Template#render'
    from active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'
    from active_support/notifications/instrumenter.rb:58:in 'instrument'
    from active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'
    from action_view/template.rb:583:in 'instrument_render_template'
    from action_view/template.rb:272:in 'render'
    from action_view/renderer/partial_renderer.rb:268:in 'block in ActionView::PartialRenderer#render_partial_template'
    from active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'
    from active_support/notifications/instrumenter.rb:58:in 'instrument'
    from active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'
    from action_view/renderer/partial_renderer.rb:262:in 'render_partial_template'
    from action_view/renderer/object_renderer.rb:31:in 'render_partial_template'
    from action_view/renderer/partial_renderer.rb:253:in 'render'
    from action_view/renderer/object_renderer.rb:16:in 'render_object_with_partial'
    from action_view/renderer/object_renderer.rb:21:in 'render_object_derive_partial'
    from action_view/renderer/renderer.rb:91:in 'render_partial_to_object'
    from action_view/renderer/renderer.rb:49:in 'render_partial'
    from action_view/helpers/rendering_helper.rb:152:in 'render'
    from bundle/ruby/3.4.0/gems/comfortable_media_surfer-3.1.5/app/views/comfy/admin/cms/pages/edit.html.haml:10
    from action_view/helpers/capture_helper.rb:50:in 'block in ActionView::Helpers::CaptureHelper#capture'
    from action_view/buffers.rb:75:in 'capture'
    from action_view/helpers/capture_helper.rb:50:in 'capture'
    from action_view/helpers/form_helper.rb:775:in 'form_with'
    from comfy_bootstrap_form/view_helper.rb:20:in 'block in ComfyBootstrapForm::ViewHelper#bootstrap_form_with'
    from comfy_bootstrap_form/view_helper.rb:51:in 'supress_form_field_errors'
    from comfy_bootstrap_form/view_helper.rb:19:in 'bootstrap_form_with'
    from bundle/ruby/3.4.0/gems/comfortable_media_surfer-3.1.5/app/helpers/comfy/admin/cms_helper.rb:11:in 'comfy_form_with'
    from bundle/ruby/3.4.0/gems/comfortable_media_surfer-3.1.5/app/views/comfy/admin/cms/pages/edit.html.haml:9
    from action_view/base.rb:281:in 'public_send'
    from action_view/base.rb:281:in '_run'
    from action_view/template.rb:284:in 'block in ActionView::Template#render'
    from active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'
    from active_support/notifications/instrumenter.rb:58:in 'instrument'
    from active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'
    from action_view/template.rb:583:in 'instrument_render_template'
    from action_view/template.rb:272:in 'render'
    from action_view/renderer/template_renderer.rb:66:in 'block (2 levels) in ActionView::TemplateRenderer#render_template'
    from active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'
    from active_support/notifications/instrumenter.rb:58:in 'instrument'
    from active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'
    from action_view/renderer/template_renderer.rb:60:in 'block in ActionView::TemplateRenderer#render_template'
    from action_view/renderer/template_renderer.rb:76:in 'block in ActionView::TemplateRenderer#render_with_layout'
    from active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'
    from active_support/notifications/instrumenter.rb:58:in 'instrument'
    from active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'
    from action_view/renderer/template_renderer.rb:75:in 'render_with_layout'
    from action_view/renderer/template_renderer.rb:59:in 'render_template'
    from action_view/renderer/template_renderer.rb:11:in 'render'
    from action_view/renderer/renderer.rb:58:in 'render_template_to_object'
    from action_view/renderer/renderer.rb:31:in 'render_to_object'
    from action_view/rendering.rb:136:in 'block in ActionView::Rendering#_render_template'
    from action_view/base.rb:308:in 'in_rendering_context'
    from action_view/rendering.rb:135:in '_render_template'
    from action_controller/metal/streaming.rb:179:in '_render_template'
    from action_view/rendering.rb:122:in 'render_to_body'
    from action_controller/metal/rendering.rb:192:in 'render_to_body'
    from action_controller/metal/renderers.rb:155:in 'render_to_body'
    from abstract_controller/rendering.rb:28:in 'render'
    from action_controller/metal/rendering.rb:173:in 'render'
    from action_controller/metal/instrumentation.rb:31:in 'block (2 levels) in ActionController::Instrumentation#render'
    from active_support/benchmark.rb:17:in 'ActiveSupport::Benchmark.realtime'
    from action_controller/metal/instrumentation.rb:31:in 'block in ActionController::Instrumentation#render'
    from action_controller/metal/instrumentation.rb:100:in 'cleanup_view_runtime'
    from active_record/railties/controller_runtime.rb:48:in 'cleanup_view_runtime'
    from action_controller/metal/instrumentation.rb:30:in 'render'
    from comfortable_media_surfer/render_methods.rb:54:in 'render'
    from bundle/ruby/3.4.0/gems/comfortable_media_surfer-3.1.5/app/controllers/comfy/admin/cms/pages_controller.rb:36:in 'edit'
    from action_controller/metal/basic_implicit_render.rb:8:in 'send_action'
    from abstract_controller/base.rb:221:in 'process_action'
    from action_controller/metal/rendering.rb:199:in 'process_action'
    from abstract_controller/callbacks.rb:267:in 'block in AbstractController::Callbacks#process_action'
    from active_support/callbacks.rb:121:in 'block in ActiveSupport::Callbacks#run_callbacks'
    from turbo-rails.rb:24:in 'Turbo.with_request_id'
    from bundle/ruby/3.4.0/gems/turbo-rails-2.0.20/app/controllers/concerns/turbo/request_id_tracking.rb:10:in 'turbo_tracking_request_id'
    from active_support/callbacks.rb:130:in 'block in ActiveSupport::Callbacks#run_callbacks'
    from sentry/rails/controller_transaction.rb:34:in 'block in Sentry::Rails::ControllerTransaction#sentry_around_action'
    from sentry/hub.rb:139:in 'with_child_span'
    from sentry-ruby.rb:526:in 'Sentry.with_child_span'
    from sentry/rails/controller_transaction.rb:18:in 'sentry_around_action'
    from active_support/callbacks.rb:130:in 'block in ActiveSupport::Callbacks#run_callbacks'
    from active_support/callbacks.rb:141:in 'run_callbacks'
    from abstract_controller/callbacks.rb:266:in 'process_action'
    from action_controller/metal/rescue.rb:36:in 'process_action'
    from action_controller/metal/instrumentation.rb:76:in 'block in ActionController::Instrumentation#process_action'
    from active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'
    from active_support/notifications/instrumenter.rb:58:in 'instrument'
    from active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'
    from action_controller/metal/instrumentation.rb:75:in 'process_action'
    from action_controller/metal/params_wrapper.rb:259:in 'process_action'
    from active_record/railties/controller_runtime.rb:39:in 'process_action'
    from abstract_controller/base.rb:154:in 'process'
    from action_view/rendering.rb:40:in 'process'
    from action_controller/metal.rb:252:in 'dispatch'
    from action_controller/metal.rb:335:in 'ActionController::Metal.dispatch'
    from action_dispatch/routing/route_set.rb:65:in 'dispatch'
    from action_dispatch/routing/route_set.rb:50:in 'serve'
    from action_dispatch/journey/router.rb:35:in 'block in ActionDispatch::Journey::Router#serve'
    from action_dispatch/journey/router.rb:86:in 'block in ActionDispatch::Journey::Router#recognize'
    from action_dispatch/journey/router.rb:66:in 'each'
    from action_dispatch/journey/router.rb:66:in 'recognize'
    from action_dispatch/journey/router.rb:31:in 'serve'
    from action_dispatch/routing/route_set.rb:906:in 'call'
    from rails-settings/middleware.rb:9:in 'call'
    from warden/manager.rb:36:in 'block in Warden::Manager#call'
    from warden/manager.rb:34:in 'catch'
    from warden/manager.rb:34:in 'call'
    from rack/tempfile_reaper.rb:20:in 'call'
    from rack/etag.rb:29:in 'call'
    from rack/conditional_get.rb:31:in 'call'
    from rack/head.rb:15:in 'call'
    from action_dispatch/http/content_security_policy.rb:38:in 'call'
    from rack/session/abstract/id.rb:274:in 'context'
    from rack/session/abstract/id.rb:268:in 'call'
    from action_dispatch/middleware/cookies.rb:708:in 'call'
    from action_dispatch/middleware/callbacks.rb:31:in 'block in ActionDispatch::Callbacks#call'
    from active_support/callbacks.rb:101:in 'run_callbacks'
    from action_dispatch/middleware/callbacks.rb:30:in 'call'
    from sentry/rails/rescued_exception_interceptor.rb:14:in 'call'
    from action_dispatch/middleware/debug_exceptions.rb:31:in 'call'
    from sentry/rack/capture_exceptions.rb:30:in 'block (2 levels) in Sentry::Rack::CaptureExceptions#call'
    from sentry/hub.rb:333:in 'with_session_tracking'
    from sentry-ruby.rb:419:in 'Sentry.with_session_tracking'
    from sentry/rack/capture_exceptions.rb:21:in 'block in Sentry::Rack::CaptureExceptions#call'
    from sentry/hub.rb:89:in 'with_scope'
    from sentry-ruby.rb:399:in 'Sentry.with_scope'
    from sentry/rack/capture_exceptions.rb:20:in 'call'
    from action_dispatch/middleware/show_exceptions.rb:32:in 'call'
    from rails/rack/logger.rb:41:in 'call_app'
    from rails/rack/logger.rb:29:in 'call'
    from rails/rack/silence_request.rb:31:in 'call'
    from action_dispatch/middleware/remote_ip.rb:98:in 'call'
    from request_store/middleware.rb:19:in 'call'
    from action_dispatch/middleware/request_id.rb:34:in 'call'
    from rack/method_override.rb:28:in 'call'
    from rack/runtime.rb:24:in 'call'
    from active_support/cache/strategy/local_cache_middleware.rb:30:in 'call'
    from action_dispatch/middleware/executor.rb:20:in 'call'
    from action_dispatch/middleware/static.rb:27:in 'call'
    from rack/sendfile.rb:131:in 'call'
    from action_dispatch/middleware/ssl.rb:92:in 'call'
    from rails/engine.rb:534:in 'call'
    from puma/configuration.rb:300:in 'call'
    from puma/request.rb:101:in 'block in Puma::Request#handle_request'
    from puma/thread_pool.rb:355:in 'with_force_shutdown'
    from puma/request.rb:100:in 'handle_request'
    from puma/server.rb:503:in 'process_client'
    from puma/server.rb:262:in 'block in Puma::Server#run'
    from puma/thread_pool.rb:182:in 'block in Puma::ThreadPool#spawn_thread'

ActionView::Template::Error: wrong number of arguments (given 1, expected 0) (ActionView::Template::Error)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date and datetime value formatting in content editing forms so date/time fields display and submit correctly.

* **Tests**
  * Added test coverage for page editing with date and datetime content fields, verifying form rendering, presence of fragments, and successful edit responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->